### PR TITLE
Add `Run` Function for Executing Shell Commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/threeal/shell-go
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.3
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/shell.go
+++ b/shell.go
@@ -1,1 +1,16 @@
+// Package shell provides functions for executing shell commands.
 package shell
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Run executes a shell command, displaying its outputs to the current process's standard outputs.
+// Returns an error if the command execution fails.
+func Run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -1,0 +1,19 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("RunSuccessfully", func(t *testing.T) {
+		err := Run("go", "version")
+		require.NoError(t, err)
+	})
+
+	t.Run("RunWithError", func(t *testing.T) {
+		err := Run("go", "invalid")
+		require.ErrorContains(t, err, "exit status")
+	})
+}


### PR DESCRIPTION
This pull request adds the `Run` function for executing shell commands and includes corresponding unit tests. The function enables execution of shell commands, providing output to the standard output and standard error streams.

Closes #3.
