### PR TITLE
Add Function for Executing Shell Commands Silently

### DIFF
--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1,0 +1,61 @@
+package shell
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requirePipeOutput redirects the standard output and error streams to a pipe,
+// allowing capturing of their content for testing purposes.
+// It returns two functions: read and restore.
+//
+// The read function asynchronously reads the content from the pipe and returns it as a string.
+//
+// The restore function restores the original standard output and error streams.
+func requirePipeOutput(t *testing.T) (read func() string, restore func()) {
+	// Save the original standard output and error streams.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	// Replace the standard output and error streams with the pipe.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	os.Stderr = w
+
+	// Function that asynchronously reads the content from the pipe and returns it as a string.
+	read = func() string {
+		out := make(chan string)
+		// Copy buffer asynchronously to prevent blocking.
+		go func() {
+			var b strings.Builder
+			_, err := io.Copy(&b, r)
+			require.NoError(t, err)
+			out <- b.String()
+		}()
+		w.Close()
+		return <-out
+	}
+
+	// Function that restores the original standard output and error streams.
+	restore = func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}
+
+	return read, restore
+}
+
+func TestRequirePipeOutput(t *testing.T) {
+	read, restore := requirePipeOutput(t)
+	defer restore()
+	fmt.Println("some log")
+	fmt.Fprintln(os.Stderr, "some error")
+	fmt.Println("some other log")
+	require.Equal(t, "some log\nsome error\nsome other log\n", read())
+}

--- a/shell.go
+++ b/shell.go
@@ -6,11 +6,18 @@ import (
 	"os/exec"
 )
 
-// Run executes a shell command, displaying its outputs to the current process's standard outputs.
+// Run executes a shell command, displaying its output to the current process's standard output.
 // Returns an error if the command execution fails.
 func Run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// RunSilently executes a shell command silently, without displaying its output.
+// Returns an error if the command execution fails.
+func RunSilently(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
 	return cmd.Run()
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -17,3 +17,15 @@ func TestRun(t *testing.T) {
 		require.ErrorContains(t, err, "exit status")
 	})
 }
+
+func TestRunSilently(t *testing.T) {
+	t.Run("RunSuccessfully", func(t *testing.T) {
+		err := RunSilently("go", "version")
+		require.NoError(t, err)
+	})
+
+	t.Run("RunWithError", func(t *testing.T) {
+		err := RunSilently("go", "invalid")
+		require.ErrorContains(t, err, "exit status")
+	})
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -8,24 +8,36 @@ import (
 
 func TestRun(t *testing.T) {
 	t.Run("RunSuccessfully", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
 		err := Run("go", "version")
 		require.NoError(t, err)
+		require.Regexp(t, "^go version go\\S+ \\S+\n$", read())
 	})
 
 	t.Run("RunWithError", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
 		err := Run("go", "invalid")
 		require.ErrorContains(t, err, "exit status")
+		require.Regexp(t, "^go invalid: unknown command\nRun 'go help' for usage.\n$", read())
 	})
 }
 
 func TestRunSilently(t *testing.T) {
 	t.Run("RunSuccessfully", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
 		err := RunSilently("go", "version")
 		require.NoError(t, err)
+		require.Empty(t, read())
 	})
 
 	t.Run("RunWithError", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
 		err := RunSilently("go", "invalid")
 		require.ErrorContains(t, err, "exit status")
+		require.Empty(t, read())
 	})
 }


### PR DESCRIPTION
This pull request introduces the following changes:

- Added a `runSilently` function that enables executing shell commands silently, without displaying their output.
- Added a `requirePipeOutput` helper function to facilitate testing the output of a function.
- Closes #5.

These changes aim to enhance the functionality of the shell package by providing a convenient method to execute commands silently and improving the testing capabilities with the new helper function.