### PR TITLE
Add Run Output Functions

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -4,10 +4,11 @@ package shell
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // Run executes a shell command, displaying its output to the current process's standard output.
-// Returns an error if the command execution fails.
+// It returns an error if the command execution fails.
 func Run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
@@ -16,8 +17,19 @@ func Run(name string, args ...string) error {
 }
 
 // RunSilently executes a shell command silently, without displaying its output.
-// Returns an error if the command execution fails.
+// It returns an error if the command execution fails.
 func RunSilently(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	return cmd.Run()
+}
+
+// OutputSilently executes a shell command silently and returns its output as a string.
+// It returns an error if the command execution fails.
+func OutputSilently(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
 }

--- a/shell.go
+++ b/shell.go
@@ -2,6 +2,7 @@
 package shell
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -21,6 +22,18 @@ func Run(name string, args ...string) error {
 func RunSilently(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	return cmd.Run()
+}
+
+// Output executes a shell command, returning its output as a string
+// and displaying its output to the current process's standard output.
+// It returns an error if the command execution fails.
+func Output(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var out strings.Builder
+	cmd.Stdout = io.MultiWriter(&out, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&out, os.Stderr)
+	err := cmd.Run()
+	return out.String(), err
 }
 
 // OutputSilently executes a shell command silently and returns its output as a string.

--- a/shell_test.go
+++ b/shell_test.go
@@ -41,3 +41,23 @@ func TestRunSilently(t *testing.T) {
 		require.Empty(t, read())
 	})
 }
+
+func TestOutputSilently(t *testing.T) {
+	t.Run("RunSuccessfully", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
+		output, err := OutputSilently("go", "version")
+		require.NoError(t, err)
+		require.Regexp(t, "^go version go\\S+ \\S+\n$", output)
+		require.Empty(t, read())
+	})
+
+	t.Run("RunWithError", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
+		output, err := OutputSilently("go", "invalid")
+		require.ErrorContains(t, err, "exit status")
+		require.Regexp(t, "^go invalid: unknown command\nRun 'go help' for usage.\n$", output)
+		require.Empty(t, read())
+	})
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -41,6 +41,25 @@ func TestRunSilently(t *testing.T) {
 		require.Empty(t, read())
 	})
 }
+func TestOutput(t *testing.T) {
+	t.Run("RunSuccessfully", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
+		output, err := Output("go", "version")
+		require.NoError(t, err)
+		require.Regexp(t, "^go version go\\S+ \\S+\n$", output)
+		require.Regexp(t, "^go version go\\S+ \\S+\n$", read())
+	})
+
+	t.Run("RunWithError", func(t *testing.T) {
+		read, restore := requirePipeOutput(t)
+		defer restore()
+		output, err := Output("go", "invalid")
+		require.ErrorContains(t, err, "exit status")
+		require.Regexp(t, "^go invalid: unknown command\nRun 'go help' for usage.\n$", output)
+		require.Regexp(t, "^go invalid: unknown command\nRun 'go help' for usage.\n$", read())
+	})
+}
 
 func TestOutputSilently(t *testing.T) {
 	t.Run("RunSuccessfully", func(t *testing.T) {


### PR DESCRIPTION
This pull request adds new output functions to the `shell` package. The following changes are introduced:
- `Output`: Executes a shell command, returning its output as a string and displaying it to the current process's standard output.
- `OutputSilently`: Executes a shell command silently and returns its output as a string.

Closes #8.
